### PR TITLE
Fix asio_service schedule issue

### DIFF
--- a/src/asio_service.cxx
+++ b/src/asio_service.cxx
@@ -538,10 +538,8 @@ void asio_service::schedule(ptr<delayed_task>& task, int32 milliseconds) {
     if (task->get_impl_context() == nilptr) {
         task->set_impl_context(new asio::steady_timer(impl_->io_svc_), &_free_timer_);
     }
-    else {
-        // this task has been scheduled before, ensure it's not in cancelled state
-        task->reset();
-    }
+    // ensure it's not in cancelled state
+    task->reset();
 
     asio::steady_timer* timer = static_cast<asio::steady_timer*>(task->get_impl_context());
     timer->expires_after(std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::milliseconds(milliseconds)));


### PR DESCRIPTION
* Even though task's impl_ctx was null, need to clear cancelled flag
as it can be independently set by delayed_task_scheduler::cancel().