### PR TITLE
CMake builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ debug/
 Debug/
 .vs/
 *.user
-asio/
+#asio/
 nbproject/
 *.obj
 *.o
@@ -13,3 +13,6 @@ nbproject/
 *.exe
 *.ilk
 *.lib
+cmake-*/
+build/
+.idea/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "asio"]
+	path = asio
+	url = https://github.com/chriskohlhoff/asio.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,204 @@
+cmake_minimum_required(VERSION 3.9)
+project(cornerstone VERSION 0.0.0 LANGUAGES CXX)
+
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
+include(CheckIPOSupported)
+
+option(BUILD_TESTS "Build unit tests" ON)
+
+add_definitions(-DASIO_STANDALONE)
+add_definitions(-DASIO_HAS_STD_CHRONO)
+
+# ASIO requires threads
+find_package(Threads REQUIRED)
+
+# Builds default to RELEASE
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE RELEASE CACHE STRING
+            "Choose the type of build, options are: None Debug Release."
+            FORCE)
+endif(NOT CMAKE_BUILD_TYPE)
+
+# Set default optimizations
+if(CMAKE_COMPILER_IS_GNUCXX)
+    set(CMAKE_CXX_FLAGS "-Wall -Wextra")
+    set(CMAKE_CXX_FLAGS_DEBUG "-g")
+    set(CMAKE_CXX_FLAGS_RELEASE "-O3")
+endif()
+
+# If no installation prefix is given manually, install locally.
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+    set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/install" CACHE STRING
+            "The install location"
+            FORCE)
+endif (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+
+set(SOURCE_FILES
+        src/asio_service.cxx
+        src/buffer.cxx
+        src/cluster_config.cxx
+        src/fs_log_store.cxx
+        src/peer.cxx
+        src/raft_server.cxx
+        src/snapshot.cxx
+        src/snapshot_sync_req.cxx
+        src/srv_config.cxx)
+
+set(TEST_SOURCE_FILES
+        tests/src/test_async_result.cxx
+        tests/src/test_buffer.cxx
+        tests/src/test_everything_together.cxx
+        tests/src/test_impls.cxx
+        tests/src/test_log_store.cxx
+        tests/src/test_logger.cxx
+        tests/src/test_ptr.cxx
+        tests/src/test_runner.cxx
+        tests/src/test_scheduler.cxx
+        tests/src/test_serialization.cxx
+        tests/src/test_strfmt.cxx)
+
+set(HEADER_FILES
+        include/asio_service.hxx
+        include/async.hxx
+        include/basic_types.hxx
+        include/buffer.hxx
+        include/cluster_config.hxx
+        include/context.hxx
+        include/cornerstone.hxx
+        include/delayed_task.hxx
+        include/delayed_task_scheduler.hxx
+        include/fs_log_store.hxx
+        include/log_entry.hxx
+        include/log_store.hxx
+        include/log_val_type.hxx
+        include/logger.hxx
+        include/msg_base.hxx
+        include/msg_type.hxx
+        include/peer.hxx
+        include/pp_util.hxx
+        include/ptr.hxx
+        include/raft_params.hxx
+        include/raft_server.hxx
+        include/req_msg.hxx
+        include/resp_msg.hxx
+        include/rpc_cli.hxx
+        include/rpc_cli_factory.hxx
+        include/rpc_exception.hxx
+        include/rpc_listener.hxx
+        include/snapshot.hxx
+        include/snapshot_sync_ctx.hxx
+        include/snapshot_sync_req.hxx
+        include/srv_config.hxx
+        include/srv_role.hxx
+        include/srv_state.hxx
+        include/state_machine.hxx
+        include/state_mgr.hxx
+        include/strfmt.hxx
+        include/timer_task.hxx)
+
+add_library(cornerstone
+        ${SOURCE_FILES}
+        ${HEADER_FILES})
+
+add_library(cornerstone::cornerstone ALIAS cornerstone)
+
+if (BUILD_TESTS)
+    enable_testing()
+    add_executable(tests
+            ${TEST_SOURCE_FILES}
+            ${HEADER_FILES})
+
+    add_test(NAME tests COMMAND $<TARGET_FILE:tests>)
+endif (BUILD_TESTS)
+
+target_link_libraries(cornerstone
+        # asio
+        Threads::Threads
+        )
+
+if (BUILD_TESTS)
+    target_link_libraries(tests
+            cornerstone)
+endif (BUILD_TESTS)
+
+set(PROJECT_PREFIX cornerstone-${cornerstone_VERSION})
+
+target_include_directories(cornerstone PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:include/${PROJECT_PREFIX}>
+        PRIVATE src ${CMAKE_CURRENT_SOURCE_DIR}/asio/asio/include)
+
+if (BUILD_TESTS)
+    target_include_directories(tests PUBLIC
+            ${CMAKE_CURRENT_SOURCE_DIR}/include
+            PRIVATE src ${CMAKE_CURRENT_SOURCE_DIR}/asio/asio/include)
+endif (BUILD_TESTS)
+
+set(PUBLIC_COMPILE_FEATURES
+        cxx_std_11
+        cxx_override
+        cxx_nullptr)
+
+target_compile_features(cornerstone
+        PUBLIC ${PUBLIC_COMPILE_FEATURES})
+
+if (BUILD_TESTS)
+    target_compile_features(tests
+            PUBLIC ${PUBLIC_COMPILE_FEATURES})
+endif (BUILD_TESTS)
+
+set(INSTALL_RUNTIME_DIR ${CMAKE_INSTALL_BINDIR})
+set(INSTALL_CONFIG_DIR  ${CMAKE_INSTALL_LIBDIR}/${PROJECT_PREFIX}/cmake)
+set(INSTALL_LIBRARY_DIR ${CMAKE_INSTALL_LIBDIR}/${PROJECT_PREFIX}/${CMAKE_BUILD_TYPE})
+set(INSTALL_ARCHIVE_DIR ${CMAKE_INSTALL_LIBDIR}/${PROJECT_PREFIX}/${CMAKE_BUILD_TYPE}/static)
+set(INSTALL_INCLUDE_DIR ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_PREFIX}/cornerstone)
+
+set(PROJECT_CONFIG_VERSION_FILE "${PROJECT_BINARY_DIR}/cornerstone-config-version.cmake")
+set(PROJECT_CONFIG_FILE         "${PROJECT_BINARY_DIR}/cornerstone-config.cmake")
+
+configure_package_config_file(cmake/cornerstone-config.cmake.in
+        ${PROJECT_CONFIG_FILE}
+        INSTALL_DESTINATION ${INSTALL_CONFIG_DIR})
+
+write_basic_package_version_file(
+        ${PROJECT_CONFIG_VERSION_FILE}
+        COMPATIBILITY SameMajorVersion)
+
+install(TARGETS cornerstone
+        EXPORT cornerstone-targets
+        RUNTIME DESTINATION ${INSTALL_RUNTIME_DIR}
+        LIBRARY DESTINATION ${INSTALL_LIBRARY_DIR}
+        ARCHIVE DESTINATION ${INSTALL_ARCHIVE_DIR})
+
+install(FILES ${HEADER_FILES}
+        DESTINATION ${INSTALL_INCLUDE_DIR})
+
+install(FILES
+        ${PROJECT_CONFIG_VERSION_FILE}
+        ${PROJECT_CONFIG_FILE}
+        DESTINATION ${INSTALL_CONFIG_DIR})
+
+install(EXPORT cornerstone-targets
+        FILE cornerstone-targets.cmake
+        NAMESPACE cornerstone::
+        DESTINATION ${INSTALL_CONFIG_DIR})
+
+export(EXPORT cornerstone-targets
+        FILE ${CMAKE_CURRENT_BINARY_DIR}/cornerstone-targets.cmake
+        NAMESPACE foo::)
+
+export(PACKAGE cornerstone)
+
+check_ipo_supported(RESULT ipo_supported)
+if(ipo_supported)
+    set_property(TARGET cornerstone PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
+endif()
+
+find_program(CCACHE_FOUND "ccache")
+if(CCACHE_FOUND)
+    set_property(TARGET cornerstone PROPERTY RULE_LAUNCH_COMPILE ccache)
+    if(BUILD_TESTS)
+        set_property(TARGET tests PROPERTY RULE_LAUNCH_LINK ccache)
+    endif(BUILD_TESTS)
+endif(CCACHE_FOUND)

--- a/cmake/cornerstone-config.cmake.in
+++ b/cmake/cornerstone-config.cmake.in
@@ -1,0 +1,17 @@
+@PACKAGE_INIT@
+
+# Include the exported CMake file
+get_filename_component(cornerstone_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+
+# This macro enables usage of find_dependency().
+# https://cmake.org/cmake/help/v3.11/module/CMakeFindDependencyMacro.html
+include(CMakeFindDependencyMacro)
+
+# Declare the used packages in order to communicate the requirements upstream.
+# find_dependency(asio ...)
+
+if(NOT TARGET cornerstone::cornerstone)
+include("${cornerstone_CMAKE_DIR}/cornerstone-targets.cmake")
+endif()
+
+check_required_components(cornerstone)


### PR DESCRIPTION
Hey there. I ported the build system to CMake and figured I should at least let you know. It's using `asio` as a git submodule at the moment, but this seems to be close to what the original build does anyway.

The commands

```bash
mkdir build && cd build
cmake ..
make
make install
```

build and install the library to `build/install` (this way you're not accidentally installing in an unwanted location). CMake projects can now use

```
find_package(cornerstone REQUIRED)
```

to find the library. Or they can submodule the repo and call `add_subdirectory(...)`.

Tests should run with

```bash
ctest 
# or
make test
```

from the `build` directory as well.